### PR TITLE
Fix dynamic herb container selection

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -6,8 +6,8 @@ const maxHerbsCount = 3;
 const addBtn = document.getElementById('add-btn');
 const removeBtn = document.getElementById('remove-btn');
 
-// Get the herbs container
-const herbsContainer = document.querySelector('.herbs-container');
+// Get the herbs container that will hold dynamically added inputs
+const herbsContainer = document.getElementById('dynamic-herbs');
 
 // Function to add a herbs input field
 function addHerbsInput() {


### PR DESCRIPTION
## Summary
- target the `div` with `id="dynamic-herbs"` for dynamic herb inputs
- ensure add/remove functions operate on this container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684108e77a54832f802f2adcaa46ff83